### PR TITLE
✨ Add claims, quests, userinfo API and balance-claim page

### DIFF
--- a/app/components/player-map/index.tsx
+++ b/app/components/player-map/index.tsx
@@ -29,6 +29,7 @@ const playerMapStyle = sva({
         },
         name: {
             fontVariationSettings: "'wght' 600",
+            filter: "blur(3px)",
             fontWeight: "600",
             fontSize: "sm",
             color: "var(--chakra-colors-color-palette-fg)",

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -9,13 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as NofooterAuthSignInIndexRouteImport } from './routes/_nofooter/auth/sign-in/index'
-import { Route as NofooterTermsIndexRouteImport } from './routes/_nofooter/terms/index'
 import { Route as Signed_inRouteImport } from './routes/_signed_in'
-import { Route as Signed_inSplatRouteImport } from './routes/_signed_in/$'
 import { Route as Signed_inIndexRouteImport } from './routes/_signed_in/index'
+import { Route as Signed_inSplatRouteImport } from './routes/_signed_in/$'
 import { Route as Signed_inMyPageIndexRouteImport } from './routes/_signed_in/my-page/index'
+import { Route as Signed_inBalanceClaimIndexRouteImport } from './routes/_signed_in/balance-claim/index'
+import { Route as NofooterTermsIndexRouteImport } from './routes/_nofooter/terms/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as NofooterAuthSignInIndexRouteImport } from './routes/_nofooter/auth/sign-in/index'
 
 const Signed_inRoute = Signed_inRouteImport.update({
   id: '/_signed_in',
@@ -36,6 +37,12 @@ const Signed_inMyPageIndexRoute = Signed_inMyPageIndexRouteImport.update({
   path: '/my-page/',
   getParentRoute: () => Signed_inRoute,
 } as any)
+const Signed_inBalanceClaimIndexRoute =
+  Signed_inBalanceClaimIndexRouteImport.update({
+    id: '/balance-claim/',
+    path: '/balance-claim/',
+    getParentRoute: () => Signed_inRoute,
+  } as any)
 const NofooterTermsIndexRoute = NofooterTermsIndexRouteImport.update({
   id: '/_nofooter/terms/',
   path: '/terms/',
@@ -57,6 +64,7 @@ export interface FileRoutesByFullPath {
   '/': typeof Signed_inIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/terms': typeof NofooterTermsIndexRoute
+  '/balance-claim': typeof Signed_inBalanceClaimIndexRoute
   '/my-page': typeof Signed_inMyPageIndexRoute
   '/auth/sign-in': typeof NofooterAuthSignInIndexRoute
 }
@@ -65,6 +73,7 @@ export interface FileRoutesByTo {
   '/': typeof Signed_inIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/terms': typeof NofooterTermsIndexRoute
+  '/balance-claim': typeof Signed_inBalanceClaimIndexRoute
   '/my-page': typeof Signed_inMyPageIndexRoute
   '/auth/sign-in': typeof NofooterAuthSignInIndexRoute
 }
@@ -75,6 +84,7 @@ export interface FileRoutesById {
   '/_signed_in/': typeof Signed_inIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/_nofooter/terms/': typeof NofooterTermsIndexRoute
+  '/_signed_in/balance-claim/': typeof Signed_inBalanceClaimIndexRoute
   '/_signed_in/my-page/': typeof Signed_inMyPageIndexRoute
   '/_nofooter/auth/sign-in/': typeof NofooterAuthSignInIndexRoute
 }
@@ -85,10 +95,18 @@ export interface FileRouteTypes {
     | '/'
     | '/api/auth/$'
     | '/terms'
+    | '/balance-claim'
     | '/my-page'
     | '/auth/sign-in'
   fileRoutesByTo: FileRoutesByTo
-  to: '/$' | '/' | '/api/auth/$' | '/terms' | '/my-page' | '/auth/sign-in'
+  to:
+    | '/$'
+    | '/'
+    | '/api/auth/$'
+    | '/terms'
+    | '/balance-claim'
+    | '/my-page'
+    | '/auth/sign-in'
   id:
     | '__root__'
     | '/_signed_in'
@@ -96,6 +114,7 @@ export interface FileRouteTypes {
     | '/_signed_in/'
     | '/api/auth/$'
     | '/_nofooter/terms/'
+    | '/_signed_in/balance-claim/'
     | '/_signed_in/my-page/'
     | '/_nofooter/auth/sign-in/'
   fileRoutesById: FileRoutesById
@@ -137,6 +156,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Signed_inMyPageIndexRouteImport
       parentRoute: typeof Signed_inRoute
     }
+    '/_signed_in/balance-claim/': {
+      id: '/_signed_in/balance-claim/'
+      path: '/balance-claim'
+      fullPath: '/balance-claim'
+      preLoaderRoute: typeof Signed_inBalanceClaimIndexRouteImport
+      parentRoute: typeof Signed_inRoute
+    }
     '/_nofooter/terms/': {
       id: '/_nofooter/terms/'
       path: '/terms'
@@ -164,12 +190,14 @@ declare module '@tanstack/react-router' {
 interface Signed_inRouteChildren {
   Signed_inSplatRoute: typeof Signed_inSplatRoute
   Signed_inIndexRoute: typeof Signed_inIndexRoute
+  Signed_inBalanceClaimIndexRoute: typeof Signed_inBalanceClaimIndexRoute
   Signed_inMyPageIndexRoute: typeof Signed_inMyPageIndexRoute
 }
 
 const Signed_inRouteChildren: Signed_inRouteChildren = {
   Signed_inSplatRoute: Signed_inSplatRoute,
   Signed_inIndexRoute: Signed_inIndexRoute,
+  Signed_inBalanceClaimIndexRoute: Signed_inBalanceClaimIndexRoute,
   Signed_inMyPageIndexRoute: Signed_inMyPageIndexRoute,
 }
 
@@ -187,9 +215,8 @@ export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
-import type { createStart } from '@tanstack/react-start'
 import type { getRouter } from './router.ts'
-
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true

--- a/app/routes/_nofooter/auth/sign-in/-api/sign-in-action.ts
+++ b/app/routes/_nofooter/auth/sign-in/-api/sign-in-action.ts
@@ -6,7 +6,7 @@ export const signInAction = createServerFn().handler(async () => {
         body: {
             providerId: "MineAuth",
             callbackURL: "/",
-            scopes: ["openid", "profile", "email"],
+            scopes: ["openid", "profile", "email", "roles"],
         },
     });
     const redirectUrl = typeof result === "string" ? result : result.url;

--- a/app/routes/_signed_in/-functions/get-my-claims.ts
+++ b/app/routes/_signed_in/-functions/get-my-claims.ts
@@ -1,0 +1,62 @@
+import { env } from "cloudflare:workers";
+import { createServerFn } from "@tanstack/react-start";
+import { auth } from "../../../lib/auth";
+
+/** GriefPrevention API の claims/me レスポンス型（OpenAPI 準拠） */
+interface ClaimsMeResponse {
+    accruedClaimBlocks: number;
+    bonusClaimBlocks: number;
+    claims: Array<{
+        area: number;
+        claimId: number;
+        greaterCorner: { world: string; x: number; y: number; z: number };
+        lesserCorner: { world: string; x: number; y: number; z: number };
+        owner: string | null;
+        world: string;
+    }>;
+    remainingClaimBlocks: number;
+    totalClaimCount: number;
+}
+
+/**
+ * MineAuth GriefPrevention API で「自分のクレーム情報」を取得する。
+ * remainingClaimBlocks が残り保護ブロック数（remainingClaimAmount）として使える。
+ */
+export const getMyClaims = createServerFn().handler(
+    // biome-ignore lint/suspicious/noExplicitAny: request is not typed
+    async ({ request }: any) => {
+        const tokenResult = await auth.api.getAccessToken({
+            body: {
+                providerId: "MineAuth",
+            },
+            headers: request.headers,
+        });
+
+        if (!tokenResult?.accessToken) {
+            throw new Error("No access token available");
+        }
+
+        const response = await fetch(
+            `${env.MAIN_SERVER_URL}/api/v1/plugins/mineauth-addon-griefprevention/claims/me`,
+            {
+                headers: {
+                    Authorization: `Bearer ${tokenResult.accessToken}`,
+                },
+            },
+        );
+
+        if (!response.ok) {
+            throw new Error("Failed to fetch my claims");
+        }
+
+        const data = (await response.json()) as ClaimsMeResponse;
+        return {
+            remainingClaimBlocks: data.remainingClaimBlocks,
+            accruedClaimBlocks: data.accruedClaimBlocks,
+            bonusClaimBlocks: data.bonusClaimBlocks,
+            totalClaimCount: data.totalClaimCount,
+        };
+    },
+);
+
+export type MyClaimsData = Awaited<ReturnType<typeof getMyClaims>>;

--- a/app/routes/_signed_in/-functions/get-quests.ts
+++ b/app/routes/_signed_in/-functions/get-quests.ts
@@ -2,11 +2,11 @@ import { env } from "cloudflare:workers";
 import { createServerFn } from "@tanstack/react-start";
 import { auth } from "../../../lib/auth";
 
-interface VaultBalanceResponse {
-    balance: number;
-}
+// クエスト情報のレスポンス型（実際のレスポンス構造に応じて調整が必要）
+// biome-ignore lint/suspicious/noExplicitAny: レスポンス構造が不明なためanyを使用
+export type QuestsResponse = any;
 
-export const getVaultBalance = createServerFn().handler(
+export const getQuests = createServerFn().handler(
     // biome-ignore lint/suspicious/noExplicitAny: request is not typed
     async ({ request }: any) => {
         const tokenResult = await auth.api.getAccessToken({
@@ -20,8 +20,10 @@ export const getVaultBalance = createServerFn().handler(
             throw new Error("No access token available");
         }
 
+        //再起動終わりました ご協力ありがとうございました
         const response = await fetch(
-            `${env.MAIN_SERVER_URL}/api/v1/plugins/mineauth-addon-vault/balance/me`,
+            `${env.SERVER_URL}res/api/v1/plugins/betonquest-dailyquest-mineauth-integration/daily-quests/me`,
+            // `http://127.0.0.1:51123/api/v1/plugins/mineauth-betonquest-addon/quests/me`,
             {
                 headers: {
                     Authorization: `Bearer ${tokenResult.accessToken}`,
@@ -30,12 +32,12 @@ export const getVaultBalance = createServerFn().handler(
         );
 
         if (!response.ok) {
-            throw new Error("Failed to fetch vault balance");
+            throw new Error("Failed to fetch quests");
         }
 
-        const data = (await response.json()) as VaultBalanceResponse;
-        return Math.round(data.balance);
+        const data = (await response.json()) as QuestsResponse;
+        return data;
     },
 );
 
-export type VaultBalanceData = Awaited<ReturnType<typeof getVaultBalance>>;
+export type QuestsData = Awaited<ReturnType<typeof getQuests>>;

--- a/app/routes/_signed_in/-functions/get-userinfo.ts
+++ b/app/routes/_signed_in/-functions/get-userinfo.ts
@@ -1,0 +1,25 @@
+import { env } from "cloudflare:workers";
+import { createServerFn } from "@tanstack/react-start";
+import { auth } from "../../../lib/auth";
+import type { UserInfoData } from "../../../types/player";
+
+export const getUserInfo = createServerFn().handler(
+    async ({ request }: any) => {
+        const tokenResult = await auth.api.getAccessToken({
+            body: {
+                providerId: "MineAuth",
+            },
+            headers: request.headers,
+        });
+
+        const response = await fetch(`${env.MAIN_SERVER_URL}/oauth2/userinfo`, {
+            headers: {
+                Authorization: `Bearer ${tokenResult.accessToken}`,
+            },
+        });
+        const data = (await response.json()) as UserInfoData;
+        return data;
+    },
+);
+
+export type UserInfoDataResponse = Awaited<ReturnType<typeof getUserInfo>>;

--- a/app/routes/_signed_in/-functions/index.ts
+++ b/app/routes/_signed_in/-functions/index.ts
@@ -1,8 +1,20 @@
 export {
+    getMyClaims,
+    type MyClaimsData,
+} from "./get-my-claims";
+export {
     getOnlinePlayers,
     type OnlinePlayersData,
 } from "./get-online-players";
 export {
+    getQuests,
+    type QuestsData,
+} from "./get-quests";
+export {
     getVaultBalance,
     type VaultBalanceData,
 } from "./get-vault-balance";
+export {
+    type PurchaseClaimBlocksData,
+    purchaseClaimBlocks,
+} from "./purchase-claim-blocks";

--- a/app/routes/_signed_in/-functions/purchase-claim-blocks.ts
+++ b/app/routes/_signed_in/-functions/purchase-claim-blocks.ts
@@ -1,0 +1,66 @@
+import { env } from "cloudflare:workers";
+import { createServerFn } from "@tanstack/react-start";
+import { auth } from "../../../lib/auth";
+
+/** 購入 API のレスポンス型（OpenAPI 準拠） */
+interface PurchaseClaimBlocksResponse {
+    newBalance: number;
+    purchased: number;
+    remainingClaimBlocks: number;
+    totalCost: number;
+}
+
+/**
+ * MineAuth GriefPrevention API で保護ブロックを購入する。
+ * どんぐり残高から指定数分が消費される。
+ */
+export const purchaseClaimBlocks = createServerFn().handler(
+    // biome-ignore lint/suspicious/noExplicitAny: ctx の型は createServerFn のコンテキストに依存する
+    async (ctx: any) => {
+        const { data, request } = ctx as {
+            data: { blockCount: number };
+            request: Request;
+        };
+        const tokenResult = await auth.api.getAccessToken({
+            body: {
+                providerId: "MineAuth",
+            },
+            headers: request.headers,
+        });
+
+        if (!tokenResult?.accessToken) {
+            throw new Error("No access token available");
+        }
+
+        const response = await fetch(
+            `${env.MAIN_SERVER_URL}/api/v1/plugins/mineauth-addon-griefprevention/claims/purchase`,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${tokenResult.accessToken}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    blockCount: data.blockCount,
+                }),
+            },
+        );
+
+        if (!response.ok) {
+            const err = (await response.json()) as {
+                error?: string;
+                message?: string;
+            };
+            throw new Error(
+                err?.message ?? err?.error ?? "Failed to purchase claim blocks",
+            );
+        }
+
+        const result = (await response.json()) as PurchaseClaimBlocksResponse;
+        return result;
+    },
+);
+
+export type PurchaseClaimBlocksData = Awaited<
+    ReturnType<typeof purchaseClaimBlocks>
+>;

--- a/app/routes/_signed_in/balance-claim/index.tsx
+++ b/app/routes/_signed_in/balance-claim/index.tsx
@@ -1,0 +1,190 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { LandPlot, Nut } from "lucide-react";
+import { useRef, useState } from "react";
+import { css, sva } from "../../../../styled-system/css";
+import { Header } from "../../../components/header";
+import { CardSquare } from "../-components/card-square";
+import {
+    getMyClaims,
+    getVaultBalance,
+    purchaseClaimBlocks,
+} from "../-functions";
+
+export const Route = createFileRoute("/_signed_in/balance-claim/")({
+    loader: async () => {
+        const [balance, claims] = await Promise.all([
+            getVaultBalance().catch(() => 0),
+            getMyClaims().catch(() => null),
+        ]);
+        return {
+            balance,
+            remainingClaimBlocks: claims?.remainingClaimBlocks ?? null,
+        };
+    },
+    component: BalanceClaimPage,
+});
+
+const pageStyle = sva({
+    slots: ["root", "title", "section", "form", "input", "button", "error"],
+    base: {
+        root: {
+            display: "flex",
+            flexDirection: "column",
+        },
+        title: {
+            fontSize: "3xl",
+            bgColor: "var(--chakra-colors-color-palette-500)",
+            color: "var(--chakra-colors-color-palette-50)",
+            padding: "0 24px",
+            height: "48px",
+            display: "flex",
+            alignItems: "center",
+            fontWeight: "bold",
+        },
+        section: {
+            padding: "16px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+        },
+        form: {
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "flex-end",
+            gap: "12px",
+        },
+        input: {
+            width: "120px",
+            padding: "8px 12px",
+            fontSize: "md",
+            border: "1px solid var(--chakra-colors-border)",
+            borderRadius: "8px",
+            bgColor: "var(--chakra-colors-bg)",
+        },
+        button: {
+            padding: "8px 20px",
+            fontSize: "md",
+            fontWeight: "bold",
+            color: "var(--chakra-colors-color-palette-50)",
+            bgColor: "var(--chakra-colors-color-palette-500)",
+            border: "none",
+            borderRadius: "8px",
+            cursor: "pointer",
+            _hover: {
+                bgColor: "var(--chakra-colors-color-palette-600)",
+            },
+            _disabled: {
+                opacity: 0.6,
+                cursor: "not-allowed",
+            },
+        },
+        error: {
+            color: "var(--chakra-colors-red-500)",
+            fontSize: "sm",
+        },
+    },
+});
+
+function BalanceClaimPage() {
+    const { balance, remainingClaimBlocks } = Route.useLoaderData();
+    const { session } = Route.useRouteContext();
+    const router = useRouter();
+    const [blockCount, setBlockCount] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError(null);
+        const num = Number(blockCount);
+        if (!Number.isInteger(num) || num <= 0) {
+            setError("1以上の整数を入力してください");
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            await purchaseClaimBlocks({ data: { blockCount: num } });
+            setBlockCount("");
+            await router.invalidate();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "購入に失敗しました");
+        } finally {
+            setIsSubmitting(false);
+            inputRef.current?.focus();
+        }
+    };
+
+    const style = pageStyle();
+
+    return (
+        <div className={style.root}>
+            <Header.Builted session={session} />
+            <div className={style.title}>
+                <h1 className={css({ lineHeight: "1" })}>残高・保護ブロック</h1>
+            </div>
+            <div className={style.section}>
+                <div
+                    className={css({
+                        display: "grid",
+                        gridTemplateColumns: "repeat(2, 1fr)",
+                        gap: "16px",
+                    })}
+                >
+                    <CardSquare
+                        icon={<Nut />}
+                        label="今の残高（どんぐり）"
+                        value={balance.toLocaleString()}
+                    />
+                    <CardSquare
+                        icon={<LandPlot />}
+                        label="remainingClaimAmount"
+                        value={
+                            remainingClaimBlocks !== null
+                                ? remainingClaimBlocks.toLocaleString()
+                                : "—"
+                        }
+                    />
+                </div>
+
+                <form className={style.form} onSubmit={handleSubmit}>
+                    <label
+                        className={css({
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "4px",
+                        })}
+                    >
+                        <span
+                            className={css({
+                                fontSize: "sm",
+                                fontWeight: "medium",
+                            })}
+                        >
+                            購入する保護ブロック数
+                        </span>
+                        <input
+                            ref={inputRef}
+                            type="number"
+                            min={1}
+                            step={1}
+                            value={blockCount}
+                            onChange={(e) => setBlockCount(e.target.value)}
+                            className={style.input}
+                            placeholder="例: 100"
+                            disabled={isSubmitting}
+                        />
+                    </label>
+                    <button
+                        type="submit"
+                        className={style.button}
+                        disabled={isSubmitting}
+                    >
+                        {isSubmitting ? "処理中…" : "購入する"}
+                    </button>
+                </form>
+                {error && <p className={style.error}>{error}</p>}
+            </div>
+        </div>
+    );
+}

--- a/app/routes/_signed_in/index.tsx
+++ b/app/routes/_signed_in/index.tsx
@@ -5,22 +5,26 @@ import { css, sva } from "../../../styled-system/css";
 import { Header } from "../../components/header";
 import { CardSquare } from "./-components/card-square";
 import { OnlineStatus } from "./-components/online-status";
-import { getOnlinePlayers, getVaultBalance } from "./-functions";
+import { getMyClaims, getOnlinePlayers, getQuests, getVaultBalance } from "./-functions";
+import { getUserInfo } from "./-functions/get-userinfo";
 
 export const Route = createFileRoute("/_signed_in/")({
     loader: async () => {
-        const [players, balance] = await Promise.all([
+        const [players, balance, userInfo, quests, claims] = await Promise.all([
             getOnlinePlayers(),
             getVaultBalance().catch(() => 0),
+            getUserInfo(),
+            getQuests().catch(() => null),
+            getMyClaims().catch(() => null),
         ]);
-        const protectionBlocks = Math.floor(Math.random() * 10000);
-        return { players, balance, protectionBlocks };
+        return { players, balance, claims, userInfo, quests };
     },
     component: Home,
 });
 
 function Home() {
-    const { players, balance, protectionBlocks } = Route.useLoaderData();
+    const { players, balance, claims, userInfo, quests } =
+        Route.useLoaderData();
     const { session } = Route.useRouteContext();
 
     const indexStyle = sva({
@@ -83,7 +87,7 @@ function Home() {
                 <CardSquare
                     icon={<LandPlot />}
                     label="保護ブロック"
-                    value={protectionBlocks.toLocaleString()}
+                    value={claims?.remainingClaimBlocks?.toLocaleString() ?? "—"}
                 />
             </div>
         </div>

--- a/app/types/player.ts
+++ b/app/types/player.ts
@@ -74,3 +74,13 @@ export interface PlayerServerData {
     uuid: string;
     server: string;
 }
+
+// ユーザー情報取得API(`/oauth2/userinfo`)の戻り値型
+export interface UserInfoData {
+    sub: string; // uuid
+    picture: string; // プロフィール画像URL
+    preferred_username: string; // 通常MCIDと同一
+    email: string; // noreplyメールアドレス
+    email_verified: boolean; // emailが認証されているか
+    roles: string[]; // ロール一覧
+}


### PR DESCRIPTION
## Summary
- MineAuth APIから claims / quests / userinfo を取得するサーバー関数を追加
- `/balance-claim` ルートを新設し、どんぐり残高から保護ブロックを購入できるページを実装
- ホームページで保護ブロック数をランダム値から実データ表示に変更
- 認証スコープに `roles` を追加、Vault APIエンドポイントを修正
- プレイヤーマップの名前にblurエフェクトを追加

## Changes
- **New files**: `get-my-claims.ts`, `get-quests.ts`, `get-userinfo.ts`, `purchase-claim-blocks.ts`, `balance-claim/index.tsx`
- **Modified**: `index.tsx` (home), `sign-in-action.ts`, `get-vault-balance.ts`, `player-map/index.tsx`, `player.ts`

## Test plan
- [ ] ログイン後のホームページで保護ブロック数が正しく表示される
- [ ] `/balance-claim` ページで残高と保護ブロック数が表示される
- [ ] 保護ブロック購入フォームが正常に動作する

Made with [Cursor](https://cursor.com)