### PR TITLE
fix: MineAuth v0.3.5 のプラグイン API パスに追従

### DIFF
--- a/app/src/routes/_signed_in/-functions/get-my-claims.ts
+++ b/app/src/routes/_signed_in/-functions/get-my-claims.ts
@@ -38,7 +38,7 @@ export const getMyClaims = createServerFn().handler(
         }
 
         const response = await fetch(
-            `${env.MAIN_SERVER_URL}/api/v1/plugins/mineauth-addon-griefprevention/claims/me`,
+            `${env.MAIN_SERVER_URL}/api/v1/plugins/griefprevention/claims/me`,
             {
                 headers: {
                     Authorization: `Bearer ${tokenResult.accessToken}`,

--- a/app/src/routes/_signed_in/-functions/get-vault-balance.ts
+++ b/app/src/routes/_signed_in/-functions/get-vault-balance.ts
@@ -22,7 +22,7 @@ export const getVaultBalance = createServerFn().handler(
         }
 
         const response = await fetch(
-            `${env.MAIN_SERVER_URL}/api/v1/plugins/mineauth-addon-vault/balance/me`,
+            `${env.MAIN_SERVER_URL}/api/v1/plugins/vault/balance/me`,
             {
                 headers: {
                     Authorization: `Bearer ${tokenResult.accessToken}`,

--- a/app/src/routes/_signed_in/-functions/purchase-claim-blocks.ts
+++ b/app/src/routes/_signed_in/-functions/purchase-claim-blocks.ts
@@ -34,7 +34,7 @@ export const purchaseClaimBlocks = createServerFn().handler(
         }
 
         const response = await fetch(
-            `${env.MAIN_SERVER_URL}/api/v1/plugins/mineauth-addon-griefprevention/claims/purchase`,
+            `${env.MAIN_SERVER_URL}/api/v1/plugins/griefprevention/claims/purchase`,
             {
                 method: "POST",
                 headers: {


### PR DESCRIPTION
## 概要
https://api.morino.party/main/openapi (MineAuth API v0.3.5) でプラグイン API のパスから `mineauth-addon-` プレフィックスが外れたため、ホームのカード（どんぐり・保護ブロック）と保護ブロック購入のエンドポイントを追従させる。

## 変更内容
- `get-vault-balance.ts`: `/api/v1/plugins/mineauth-addon-vault/balance/me` → `/api/v1/plugins/vault/balance/me`
- `get-my-claims.ts`: `/api/v1/plugins/mineauth-addon-griefprevention/claims/me` → `/api/v1/plugins/griefprevention/claims/me`
- `purchase-claim-blocks.ts`: `/api/v1/plugins/mineauth-addon-griefprevention/claims/purchase` → `/api/v1/plugins/griefprevention/claims/purchase`

レスポンス型は既存定義がスペックと一致しているため URL のみの変更。`tsc --noEmit` 通過確認済み。